### PR TITLE
ci: remove push trigger for check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   checks:


### PR DESCRIPTION
We can do this as pushing to main is blocked